### PR TITLE
Fix: Remove gc-cons-threshold setting

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -28,9 +28,7 @@
 
 
 
-(setq gc-cons-threshold 500000000)
 (setq read-process-output-max (* 1024 1024)) ;;1mb
-(setq lsp-print-io t)
 
 ;; ==================================================
 ;; ===============End Custom Config==================


### PR DESCRIPTION
This was way to high and caused infrequent stop the world gc's